### PR TITLE
Experimental first pass at UIViewController support

### DIFF
--- a/CheatCodes.podspec
+++ b/CheatCodes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CheatCodes'
-  s.version          = '0.2.1'
+  s.version          = '0.3.0'
   s.summary          = 'UIKeyCommand shortcuts for debugging applications in the simulator'
 
   s.description      = <<-DESC
@@ -14,8 +14,6 @@ Available Cheat Codes:
  ⌘ + ⇧ + ^ + ↓: Trigger restorable state preservation
      ⇧ + ^ + d: Print documents directory path
      ⇧ + ^ + e: Re-enable user interaction
-     ⌘ + ⌥ + f: Reset all first run screens
-     ⇧ + ^ + g: Log in a default user account
      ⇧ + ^ + h: Print the list of available commands
      ⇧ + ^ + i: Print general device info
      ⇧ + ^ + l: Print autolayout backtrace
@@ -36,8 +34,7 @@ DESC
   s.source_files = 'CheatCodes/Classes/**/*'
 
   s.pod_target_xcconfig = {
-    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'CHEAT_${CONFIGURATION}',
-    'SWIFT_VERSION' => '3.0'
-    }
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'CHEATS_${CONFIGURATION}',
+  }
 
 end

--- a/CheatCodes/Classes/CheatCodeCommand.swift
+++ b/CheatCodes/Classes/CheatCodeCommand.swift
@@ -3,9 +3,34 @@ import UIKit
 
 /// A descriptor for a CheatCodeCommand that wraps a UIKeyCommand
 public struct CheatCodeCommand {
+    /** A single-character string constant that will trigger this command when 
+        pressed along with `modifierFlags`
+    
+    - note: Also supports these constants:
+    - UIKeyInputUpArrow
+    - UIKeyInputDownArrow
+    - UIKeyInputLeftArrow
+    - UIKeyInputRightArrow
+    - UIKeyInputEscape
+    */
     public let input: String
+
+    /** A set of `UIKeyModifierFlags` that must be help along with `input` to
+        trigger the `UIKeyCommand`
+        
+    - note: The current default is `[.control, .shift]`
+    - note: When using the iOS simulator, `.option` may cause issues due to 
+            being used as part of the "Pinch" gesture support. Suggested flags
+            are: `[.control, .shift]`, `[.control, .command]`
+            and `[.control, .command, .shift]`
+    */
     public let modifierFlags: UIKeyModifierFlags
+
+    /// The `#selector` to call when the key command is activated
     public let action: Selector
+
+    /// A description used in an on-screen overlay (on iPad) and in the default
+    /// help output for `CheatCodes` in the debug console
     public let discoverabilityTitle: String
 
 

--- a/CheatCodes/Classes/CheatCodeCommand.swift
+++ b/CheatCodes/Classes/CheatCodeCommand.swift
@@ -28,6 +28,7 @@ public struct CheatCodeCommand {
 }
 
 internal extension CheatCodeCommand {
+
     func toKeyCommand() -> UIKeyCommand {
         if #available(iOS 9.0, *) {
             return UIKeyCommand(input: input, modifierFlags: modifierFlags, action: action, discoverabilityTitle: discoverabilityTitle)

--- a/CheatCodes/Classes/CheatCodeResponder.swift
+++ b/CheatCodes/Classes/CheatCodeResponder.swift
@@ -1,0 +1,40 @@
+/** 
+    Protocol that indicates a `UIViewController` has opted in to using `CheatCodes`
+    
+    - requires: Must call `addCheatCodes()` in `viewDidLoad` method to install
+                `UIKeyCommands`
+    - warning: you are strongly encouraged to wrap your extension in an `#if` block 
+                so that it will not be compiled for your app store releases.
+
+            #if CHEATS_ENABLED
+            extension MyViewController: CheatCodeResponder { ... }
+            #endif
+*/
+public protocol CheatCodeResponder: class {
+    var cheatCodes: [CheatCodeCommand] { get }
+}
+
+/** Extenstion to trigger installing `UIKeyCommand`s from `CheatCodeCommands` defined
+    in the `UIViewController`'s `cheatCodes` computed var.
+    
+    - seealso: CheatCodeResponder
+*/
+public extension UIViewController {
+    #if CHEATS_Release
+    /// :nodoc:
+    @available(iOS 9.0, *)
+    func addCheatCodes() { /* Don't do anything in Release builds */ }
+    #else
+    /**
+    Add the cheat codes defined by this ViewController's `cheatCodes` computed var
+    - requires: conformance to `CheatCodeResponder`
+    */
+    @available(iOS 9.0, *)
+    func addCheatCodes() {
+        guard let viewController = self as? CheatCodeResponder else { return }
+        viewController.cheatCodes.forEach { code in
+            addKeyCommand(code.toKeyCommand())
+        }
+    }
+    #endif
+}

--- a/CheatCodes/Classes/CheatCodes.swift
+++ b/CheatCodes/Classes/CheatCodes.swift
@@ -14,7 +14,10 @@ fileprivate extension Cheat {
 }
 
 // MARK: - Cheat Codes Public Infterface
-/// CheatCodes additions
+/**
+ Cheat code extensions for `UIKeyCommand` -- adding them here privately makes them
+ accessible when installing them at the `AppDelegate` level.
+ */
 extension UIKeyCommand {
 
     #if CHEATS_Release
@@ -58,25 +61,6 @@ extension UIKeyCommand {
         contents(&formatter)
         formatter.printContents()
     }
-}
-
-public protocol CheatCodeResponder: CustomDebugStringConvertible {
-    var cheatCodes: [CheatCodeCommand] { get }
-}
-
-public extension UIResponder {
-
-    func addCheatCodes() {
-        if #available(iOS 9.0, *) {
-            guard let viewController = self as? UIViewController, viewController is CheatCodeResponder else { return }
-            (self as! CheatCodeResponder).cheatCodes.forEach { code in
-                viewController.addKeyCommand(code.toKeyCommand())
-            }
-        } else {
-            // Fallback on earlier versions
-        }
-    }
-
 }
 
 // MARK: - Cheat Codes Private Interface

--- a/CheatCodes/Classes/FormattedKeyValuePrinter.swift
+++ b/CheatCodes/Classes/FormattedKeyValuePrinter.swift
@@ -5,14 +5,20 @@ import Foundation
  the title, and the dictionary with the keys right aligned to the longest key.
  */
 public struct FormattedKeyValuePrinter {
+    /// A title for the generated output
     public let title: String
-    var keyValuePairs = [(String,String)]()
-    var maxKeyLength = 0
+
+    private var keyValuePairs = [(String,String)]()
+    private var maxKeyLength = 0
 
     init(title: String) {
         self.title = title
     }
 
+    /** Add a key and value to the formatted output
+    - parameter key: a descriptor for the value shown
+    - parameter value: the relevant piece of data being described
+    */
     public mutating func addKey(_ key: String, value: String?) {
         maxKeyLength = max(maxKeyLength, key.characters.count)
         keyValuePairs.append((key,value ?? "(NO VALUE)"))

--- a/CheatCodes/Classes/UIKeyModifierFlags.swift
+++ b/CheatCodes/Classes/UIKeyModifierFlags.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-extension UIKeyModifierFlags {
+internal extension UIKeyModifierFlags {
 
     func printableKeys() -> String {
         return [

--- a/Example/CheatCodes/Base.lproj/Main.storyboard
+++ b/Example/CheatCodes/Base.lproj/Main.storyboard
@@ -1,25 +1,69 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yVr-ks-YoS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="CheatCodes_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
+                    <navigationItem key="navigationItem" id="as5-NX-Qdb">
+                        <barButtonItem key="rightBarButtonItem" title="Item" id="d3z-al-NOf">
+                            <connections>
+                                <segue destination="0qe-Gc-tya" kind="show" id="Y1G-Fd-t79"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="654" y="162"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Pl2-Q2-Crb">
+            <objects>
+                <viewController id="0qe-Gc-tya" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="CpK-dr-s2t"/>
+                        <viewControllerLayoutGuide type="bottom" id="7O5-h4-PwK"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="w11-Au-qVb">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="nHa-dJ-EHn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1374" y="162"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="o0f-B0-NE8">
+            <objects>
+                <navigationController id="yVr-ks-YoS" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="U4F-Hr-hJV">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="vXZ-lx-hvc" kind="relationship" relationship="rootViewController" id="7Fk-cX-2ZT"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x55-Nx-7Ne" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-167" y="163"/>
         </scene>
     </scenes>
 </document>

--- a/Example/CheatCodes/ViewController.swift
+++ b/Example/CheatCodes/ViewController.swift
@@ -25,7 +25,9 @@ class ViewController: UIViewController {
         }
 
         // We need to `opt in` somewhere
-        addCheatCodes()
+        if #available(iOS 9.0, *) {
+            addCheatCodes()
+        }
     }
 
     func showFirstTimeView() {

--- a/Example/CheatCodes/ViewController.swift
+++ b/Example/CheatCodes/ViewController.swift
@@ -7,18 +7,39 @@
 //
 
 import UIKit
+import CheatCodes
 
 class ViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+    let firstRunKey = "showedFirstRunView"
+
+    var hasSeenFirstTimeView: Bool {
+        get { return UserDefaults.standard.bool(forKey: firstRunKey) }
+        set { UserDefaults.standard.set(hasSeenFirstTimeView, forKey: firstRunKey) }
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if !hasSeenFirstTimeView {
+            showFirstTimeView()
+        }
+
+        // We need to `opt in` somewhere
+        addCheatCodes()
+    }
+
+    func showFirstTimeView() {
+        hasSeenFirstTimeView = true
+        // Add a view over the whole main view
+        print("Gonna show a view!")
     }
 
 }
 
+extension ViewController: CheatCodeResponder {
+    var cheatCodes: [CheatCodeCommand] {
+        return [
+            CheatCodeCommand(input: UIKeyInputUpArrow, modifierFlags: [.control,.command], action: #selector(showFirstTimeView), discoverabilityTitle: "Show the 'first time' screen")
+        ]
+    }
+}

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		8E3194D934DDEC10B42FC04A3153EEC6 /* Pods-CheatCodes_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BABA845FFEFF5932EEC617A8EFC022A /* Pods-CheatCodes_Tests-dummy.m */; };
 		C9670584F7BCB0F372E9A50CD38754EB /* Pods-CheatCodes_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DB8B9C39F83B6BDC20EBBA3020BBCD8D /* Pods-CheatCodes_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBE472AC6AEE305A4A3CAE3C12472C95 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEC22C73C1608DFA5D5D78BDCB218219 /* Foundation.framework */; };
+		D530FA8D1D9D8E3400A404ED /* CheatCodeResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D530FA8C1D9D8E3400A404ED /* CheatCodeResponder.swift */; };
 		D543B1131D84D05600103639 /* CheatCodeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543B1121D84D05600103639 /* CheatCodeCommand.swift */; };
 		D543B1151D84D0CA00103639 /* UIKeyModifierFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = D543B1141D84D0CA00103639 /* UIKeyModifierFlags.swift */; };
 		D5DD5CFE1D8F572100BFA475 /* FormattedKeyValuePrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DD5CFD1D8F572000BFA475 /* FormattedKeyValuePrinter.swift */; };
@@ -61,6 +62,7 @@
 		CD4690E310F3C3AB85EADDEFD2DFDF69 /* CheatCodes-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CheatCodes-prefix.pch"; sourceTree = "<group>"; };
 		CD8941ECAE0440A44385894602C654FC /* Pods-CheatCodes_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-CheatCodes_Tests.modulemap"; sourceTree = "<group>"; };
 		CEC22C73C1608DFA5D5D78BDCB218219 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		D530FA8C1D9D8E3400A404ED /* CheatCodeResponder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheatCodeResponder.swift; sourceTree = "<group>"; };
 		D543B1121D84D05600103639 /* CheatCodeCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheatCodeCommand.swift; sourceTree = "<group>"; };
 		D543B1141D84D0CA00103639 /* UIKeyModifierFlags.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKeyModifierFlags.swift; sourceTree = "<group>"; };
 		D5DD5CFD1D8F572000BFA475 /* FormattedKeyValuePrinter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattedKeyValuePrinter.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				D543B1121D84D05600103639 /* CheatCodeCommand.swift */,
+				D530FA8C1D9D8E3400A404ED /* CheatCodeResponder.swift */,
 				099EB141C22C531B316079935A43CD21 /* CheatCodes.swift */,
 				D5DD5CFD1D8F572000BFA475 /* FormattedKeyValuePrinter.swift */,
 				D543B1141D84D0CA00103639 /* UIKeyModifierFlags.swift */,
@@ -359,6 +362,7 @@
 				D543B1131D84D05600103639 /* CheatCodeCommand.swift in Sources */,
 				D543B1151D84D0CA00103639 /* UIKeyModifierFlags.swift in Sources */,
 				8D5889B0A643C2FBC89BD999196E001C /* CheatCodes.swift in Sources */,
+				D530FA8D1D9D8E3400A404ED /* CheatCodeResponder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -543,6 +547,7 @@
 				PRODUCT_NAME = CheatCodes;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "CHEATS_${CONFIGURATION}";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -648,6 +653,7 @@
 				PRODUCT_NAME = CheatCodes;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "CHEATS_${CONFIGURATION}";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/README.md
+++ b/README.md
@@ -51,7 +51,32 @@ class AppDelegate {
 }
 ```
 
-### Adding Custom Commands
+### Adding Custom Commands (to a view controller)
+
+```swift
+import UIKit
+import CheatCodes
+class MyViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // When compiled for a release build, this method does nothing
+        addCheatCodes()
+    }
+}
+
+#if CHEATS_ENABLED
+extension MyViewController: CheatCodeResponder {
+    var cheatCodes: [CheatCodeCommand] {
+        return [
+            CheatCodeCommand(input: UIKeyInputUpArrow, modifierFlags: [.control,.command], action: #selector(showFirstTimeView), discoverabilityTitle: "Show the 'first time' screen")
+        ]
+    }
+}
+#endif
+```
+
+### Adding Custom Commands (global)
 
 ```swift
 #if CHEATS_ENABLED


### PR DESCRIPTION
I would like to make adding Cheat Codes as seamless as possible for existing apps, and require minimal additional work. To that end, this pull request is one possible solution to enabling any arbitrary viewcontroller to get `help` output and avoid having to directly use `UIKeyCommand` for debug work.

To opt in, your `UIViewController` subclass:
- Conforms to `CheatCodeResponder`

``` swift
public protocol CheatCodeResponder: CustomDebugStringConvertible {
    var cheatCodes: [CheatCodeCommand] { get }
}
```
- Calls `addCheatCodes()` in `viewDidLoad` to have the `UIKeyCommands` registered behind the scenes.

In order for the `help` method to find all CheatCodes in the current responder chain, I'm using `_deepestUnambiguousResponder` on `UIWindow` to find the bottom of the responder chain, and then walking back upward myself to print out the chained commands.
